### PR TITLE
Change Nodestake.top to NodeStake

### DIFF
--- a/terpnetwork/chain.json
+++ b/terpnetwork/chain.json
@@ -71,7 +71,7 @@
       },
       {
         "address": "https://rpc.terp.nodestake.top:443",
-        "provider": "Nodestake.top"
+        "provider": "NodeStake"
       }
     ],
     "rest": [
@@ -81,7 +81,7 @@
       },
       {
         "address": "https://rpc.terp.nodestake.top:443",
-        "provider": "Nodestake.top"
+        "provider": "NodeStake"
       },
       {
         "address": "https://api.terp.network:443",
@@ -91,7 +91,7 @@
     "grpc": [
       {
         "address": "https://grpc.terp.nodestake.top:443",
-        "provider": "Nodestake.top"
+        "provider": "NodeStake"
       }
     ]
   },


### PR DESCRIPTION
Now we are used to the chain-registry name being NodeStake, the same as our verifier name